### PR TITLE
Add privacy policies and EULAs for BP Companion and TrumpAccount

### DIFF
--- a/bpcompanion/eula/index.html
+++ b/bpcompanion/eula/index.html
@@ -1,0 +1,72 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BP Companion - End User License Agreement</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 700px; margin: 0 auto; padding: 24px; color: #222; line-height: 1.6; }
+  h1 { font-size: 24px; }
+  h2 { font-size: 18px; margin-top: 32px; }
+  p, li { font-size: 15px; }
+  .date { color: #666; font-size: 14px; }
+</style>
+</head>
+<body>
+<h1>End User License Agreement (EULA)</h1>
+<p class="date">Last updated: February 6, 2026</p>
+
+<p>This End User License Agreement ("Agreement") is a legal agreement between you ("User") and Terror LLC ("Company", "we", "our") for the use of BP Companion ("the App"). By downloading, installing, or using the App, you agree to be bound by the terms of this Agreement.</p>
+
+<h2>1. License Grant</h2>
+<p>We grant you a limited, non-exclusive, non-transferable, revocable license to use the App on any Apple device that you own or control, subject to the terms of this Agreement and Apple's Usage Rules set forth in the App Store Terms of Service.</p>
+
+<h2>2. Not Medical Advice</h2>
+<p><strong>IMPORTANT:</strong> BP Companion is a health tracking tool only and does NOT provide medical advice, diagnoses, or treatment recommendations. The App is intended for informational and personal tracking purposes only. The information provided by the App, including trends, charts, and insights, should not be used as a substitute for professional medical advice, diagnosis, or treatment. Always seek the advice of your physician or other qualified health provider with any questions you may have regarding a medical condition. Never disregard professional medical advice or delay in seeking it because of information provided by this App. If you think you may have a medical emergency, call your doctor or emergency services immediately.</p>
+
+<h2>3. Subscription Terms</h2>
+<p>BP Companion offers optional premium features through auto-renewable subscriptions. By purchasing a subscription:</p>
+<ul>
+  <li>Payment will be charged to your Apple ID account at the confirmation of purchase</li>
+  <li>Your subscription will automatically renew unless auto-renew is turned off at least 24 hours before the end of the current subscription period</li>
+  <li>Your account will be charged for renewal within 24 hours prior to the end of the current period at the same price</li>
+  <li>You can manage and cancel your subscriptions by going to your Account Settings on the App Store after purchase</li>
+  <li>Any unused portion of a free trial period, if offered, will be forfeited when you purchase a subscription</li>
+</ul>
+
+<h2>4. User Responsibilities</h2>
+<p>You agree to:</p>
+<ul>
+  <li>Use the App only for its intended purpose of personal health tracking</li>
+  <li>Provide accurate information when creating your account</li>
+  <li>Maintain the security of your account credentials</li>
+  <li>Not attempt to reverse-engineer, decompile, or disassemble the App</li>
+  <li>Not use the App for any unlawful purpose</li>
+  <li>Not reproduce, distribute, or create derivative works from the App</li>
+</ul>
+
+<h2>5. Health Data</h2>
+<p>You acknowledge that any health data you enter into the App, including blood pressure readings, heart rate data, and medication information, is your own responsibility. You are responsible for the accuracy of the data you input. The App stores this data to provide its tracking functionality but makes no guarantees about the accuracy or completeness of any insights derived from this data.</p>
+
+<h2>6. Account Deletion</h2>
+<p>You may delete your account and all associated data at any time from within the App's settings or by contacting us at <a href="mailto:support@terrorllc.com">support@terrorllc.com</a>. Deleting your account will permanently remove all your stored data, including health readings and medication logs.</p>
+
+<h2>7. Disclaimer of Warranties</h2>
+<p>THE APP IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE APP WILL BE UNINTERRUPTED, ERROR-FREE, OR COMPLETELY SECURE. WE MAKE NO WARRANTIES REGARDING THE ACCURACY OR RELIABILITY OF ANY HEALTH-RELATED INFORMATION PROVIDED THROUGH THE APP.</p>
+
+<h2>8. Limitation of Liability</h2>
+<p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL TERROR LLC BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM (A) YOUR USE OR INABILITY TO USE THE APP; (B) ANY HEALTH DECISIONS MADE BASED ON INFORMATION PROVIDED BY THE APP; (C) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SERVERS AND/OR ANY PERSONAL OR HEALTH INFORMATION STORED THEREIN.</p>
+
+<h2>9. Termination</h2>
+<p>We may terminate or suspend your access to the App at any time, without prior notice or liability, for any reason, including if you breach the terms of this Agreement. Upon termination, your right to use the App will immediately cease.</p>
+
+<h2>10. Governing Law</h2>
+<p>This Agreement shall be governed by and construed in accordance with the laws of the State of Texas, United States, without regard to its conflict of law provisions.</p>
+
+<h2>11. Changes to This Agreement</h2>
+<p>We reserve the right to modify this Agreement at any time. Changes will be reflected by updating the date at the top of this page. Your continued use of the App after changes are posted constitutes your acceptance of the revised Agreement.</p>
+
+<h2>12. Contact</h2>
+<p>If you have questions about this Agreement, contact us at: <a href="mailto:support@terrorllc.com">support@terrorllc.com</a></p>
+</body>
+</html>

--- a/bpcompanion/privacy-policy/index.html
+++ b/bpcompanion/privacy-policy/index.html
@@ -1,0 +1,85 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>BP Companion - Privacy Policy</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 700px; margin: 0 auto; padding: 24px; color: #222; line-height: 1.6; }
+  h1 { font-size: 24px; }
+  h2 { font-size: 18px; margin-top: 32px; }
+  p, li { font-size: 15px; }
+  .date { color: #666; font-size: 14px; }
+</style>
+</head>
+<body>
+<h1>Privacy Policy</h1>
+<p class="date">Last updated: February 6, 2026</p>
+
+<p>BP Companion ("we", "our", or "the app") is a mobile application developed by Terror LLC that helps you track and monitor your blood pressure and heart rate readings. Your health data is sensitive, and we take its privacy and security very seriously. This policy describes how we collect, use, and protect your information.</p>
+
+<h2>Information We Collect</h2>
+<ul>
+  <li><strong>Account Information:</strong> When you sign in with Apple, we receive your Apple ID email address (or a private relay address) and a unique user identifier. We use this solely to create and manage your account.</li>
+  <li><strong>Blood Pressure Readings:</strong> Systolic and diastolic blood pressure measurements you record in the app, including dates, times, and any notes you add.</li>
+  <li><strong>Heart Rate Data:</strong> Heart rate measurements you record or sync from Apple Health.</li>
+  <li><strong>Medication Information:</strong> Any medication details you choose to log within the app, such as medication names, dosages, and schedules.</li>
+  <li><strong>Apple HealthKit Data:</strong> With your explicit permission, we read blood pressure and heart rate data from Apple HealthKit and may write your recorded measurements back to HealthKit. We only access the specific health data categories you authorize.</li>
+  <li><strong>Subscription Information:</strong> If you subscribe to BP Companion Premium, purchase and subscription status is managed through Apple's StoreKit in-app purchase system.</li>
+</ul>
+
+<h2>How We Use Your Information</h2>
+<ul>
+  <li>To authenticate your account and provide app functionality</li>
+  <li>To store and display your blood pressure and heart rate history</li>
+  <li>To sync health data with Apple HealthKit when you grant permission</li>
+  <li>To track your medication schedule and send optional reminders</li>
+  <li>To generate trends, charts, and insights from your health data</li>
+  <li>To manage your subscription status</li>
+</ul>
+
+<h2>HealthKit Data</h2>
+<p>BP Companion integrates with Apple HealthKit to read and write blood pressure and heart rate data. Your HealthKit data is handled with the highest level of care:</p>
+<ul>
+  <li>HealthKit data is only accessed with your explicit permission</li>
+  <li>HealthKit data is never sold, shared with third parties for advertising, or used for purposes unrelated to providing app functionality</li>
+  <li>HealthKit data is stored securely and encrypted in transit</li>
+  <li>You can revoke HealthKit access at any time through your device's Settings</li>
+</ul>
+
+<h2>Third-Party Services</h2>
+<p>We use the following third-party services:</p>
+<ul>
+  <li><strong>Supabase:</strong> Authentication and database storage for your account and health records</li>
+  <li><strong>Apple HealthKit:</strong> Reading and writing blood pressure and heart rate data with your permission</li>
+  <li><strong>Apple StoreKit:</strong> Subscription and in-app purchase management</li>
+  <li><strong>Apple Sign In:</strong> Authentication</li>
+</ul>
+
+<h2>Data Retention</h2>
+<p>Your account data, health readings, and medication information are retained as long as your account is active. You may delete your account and all associated data at any time from within the app's settings, or by contacting us directly.</p>
+
+<h2>Data Sharing</h2>
+<p>We do not sell, trade, or share your personal information or health data with third parties for advertising or marketing purposes. Data is only shared with the third-party services listed above as necessary to provide app functionality. Your health data is never shared with advertisers, data brokers, or any parties beyond what is required to operate the app.</p>
+
+<h2>Data Security</h2>
+<p>We use industry-standard security measures to protect your sensitive health data, including encrypted connections (HTTPS/TLS), secure authentication, encrypted database storage, and strict access controls. Health data is treated with the same level of care as protected health information.</p>
+
+<h2>Children's Privacy</h2>
+<p>BP Companion is not directed at children under 13. We do not knowingly collect personal information from children under 13.</p>
+
+<h2>Your Rights</h2>
+<ul>
+  <li>You can view all data stored in your account at any time within the app</li>
+  <li>You can delete your account and all associated data from the app's settings</li>
+  <li>You can revoke HealthKit permissions at any time through your device's Settings</li>
+  <li>You can request a copy of your data by contacting us</li>
+</ul>
+
+<h2>Changes to This Policy</h2>
+<p>We may update this policy from time to time. Changes will be reflected by updating the date at the top of this page.</p>
+
+<h2>Contact</h2>
+<p>If you have questions about this privacy policy or want to request data deletion, contact us at: <a href="mailto:support@terrorllc.com">support@terrorllc.com</a></p>
+</body>
+</html>

--- a/trumpaccount/eula/index.html
+++ b/trumpaccount/eula/index.html
@@ -1,0 +1,79 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TrumpAccount - End User License Agreement</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 700px; margin: 0 auto; padding: 24px; color: #222; line-height: 1.6; }
+  h1 { font-size: 24px; }
+  h2 { font-size: 18px; margin-top: 32px; }
+  p, li { font-size: 15px; }
+  .date { color: #666; font-size: 14px; }
+</style>
+</head>
+<body>
+<h1>End User License Agreement (EULA)</h1>
+<p class="date">Last updated: February 6, 2026</p>
+
+<p>This End User License Agreement ("Agreement") is a legal agreement between you ("User") and Terror LLC ("Company", "we", "our") for the use of TrumpAccount ("the App"). By downloading, installing, or using the App, you agree to be bound by the terms of this Agreement.</p>
+
+<h2>1. License Grant</h2>
+<p>We grant you a limited, non-exclusive, non-transferable, revocable license to use the App on any Apple device that you own or control, subject to the terms of this Agreement and Apple's Usage Rules set forth in the App Store Terms of Service.</p>
+
+<h2>2. Not Financial Advice</h2>
+<p><strong>IMPORTANT:</strong> TrumpAccount is a personal tracking and record-keeping tool only and does NOT provide financial advice, tax advice, investment recommendations, or legal guidance. The App is intended for informational and personal tracking purposes only. The information provided by the App, including contribution summaries and account balances, should not be used as a substitute for professional financial, tax, or legal advice. Always consult a qualified financial advisor, tax professional, or attorney for questions regarding 530A accounts, tax implications, investment decisions, or any other financial matters. We make no representations about the tax treatment or legal status of any contributions tracked in the App.</p>
+
+<h2>3. No Government Affiliation</h2>
+<p><strong>IMPORTANT:</strong> TrumpAccount is an independent third-party application developed by Terror LLC. The App is NOT affiliated with, endorsed by, sponsored by, or connected in any way to the United States government, the Internal Revenue Service (IRS), the Department of the Treasury, or any federal, state, or local government agency. Any references to government programs, account types, or policies within the App are for informational purposes only and may not reflect the most current rules or regulations.</p>
+
+<h2>4. Subscription Terms</h2>
+<p>TrumpAccount offers optional premium features through auto-renewable subscriptions. By purchasing a subscription:</p>
+<ul>
+  <li>Payment will be charged to your Apple ID account at the confirmation of purchase</li>
+  <li>Your subscription will automatically renew unless auto-renew is turned off at least 24 hours before the end of the current subscription period</li>
+  <li>Your account will be charged for renewal within 24 hours prior to the end of the current period at the same price</li>
+  <li>You can manage and cancel your subscriptions by going to your Account Settings on the App Store after purchase</li>
+  <li>Any unused portion of a free trial period, if offered, will be forfeited when you purchase a subscription</li>
+</ul>
+
+<h2>5. User Responsibilities</h2>
+<p>You agree to:</p>
+<ul>
+  <li>Use the App only for its intended purpose of personal savings tracking</li>
+  <li>Provide accurate information when creating your account</li>
+  <li>Maintain the security of your account credentials</li>
+  <li>Ensure that any children's information you enter is accurate and that you have the legal authority to provide it</li>
+  <li>Not attempt to reverse-engineer, decompile, or disassemble the App</li>
+  <li>Not use the App for any unlawful purpose</li>
+  <li>Not reproduce, distribute, or create derivative works from the App</li>
+</ul>
+
+<h2>6. Children's Information</h2>
+<p>You acknowledge that any children's personal information you enter into the App, including names, dates of birth, and partial SSN data, is entered at your own discretion and responsibility. You represent that you are the parent or legal guardian of any children whose information you add, or that you have obtained proper authorization to enter such information. The App stores this data to provide its tracking functionality.</p>
+
+<h2>7. Financial Data</h2>
+<p>You acknowledge that any financial data you enter into the App, including contribution amounts and account details, is your own responsibility. The App is a tracking tool and does not verify, validate, or guarantee the accuracy of any financial information. You are solely responsible for maintaining accurate records for tax and legal purposes outside of the App.</p>
+
+<h2>8. Account Deletion</h2>
+<p>You may delete your account and all associated data at any time from within the App's settings or by contacting us at <a href="mailto:support@terrorllc.com">support@terrorllc.com</a>. Deleting your account will permanently remove all your stored data, including children's information and financial records.</p>
+
+<h2>9. Disclaimer of Warranties</h2>
+<p>THE APP IS PROVIDED "AS IS" AND "AS AVAILABLE" WITHOUT WARRANTIES OF ANY KIND, EITHER EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO IMPLIED WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE, AND NON-INFRINGEMENT. WE DO NOT WARRANT THAT THE APP WILL BE UNINTERRUPTED, ERROR-FREE, OR COMPLETELY SECURE. WE MAKE NO WARRANTIES REGARDING THE ACCURACY, COMPLETENESS, OR RELIABILITY OF ANY FINANCIAL INFORMATION, CALCULATIONS, OR SUMMARIES PROVIDED THROUGH THE APP.</p>
+
+<h2>10. Limitation of Liability</h2>
+<p>TO THE MAXIMUM EXTENT PERMITTED BY APPLICABLE LAW, IN NO EVENT SHALL TERROR LLC BE LIABLE FOR ANY INDIRECT, INCIDENTAL, SPECIAL, CONSEQUENTIAL, OR PUNITIVE DAMAGES, OR ANY LOSS OF PROFITS OR REVENUES, WHETHER INCURRED DIRECTLY OR INDIRECTLY, OR ANY LOSS OF DATA, USE, GOODWILL, OR OTHER INTANGIBLE LOSSES, RESULTING FROM (A) YOUR USE OR INABILITY TO USE THE APP; (B) ANY FINANCIAL DECISIONS MADE BASED ON INFORMATION PROVIDED BY THE APP; (C) ANY TAX CONSEQUENCES OR PENALTIES ARISING FROM YOUR USE OF THE APP; (D) ANY UNAUTHORIZED ACCESS TO OR USE OF OUR SERVERS AND/OR ANY PERSONAL OR FINANCIAL INFORMATION STORED THEREIN.</p>
+
+<h2>11. Termination</h2>
+<p>We may terminate or suspend your access to the App at any time, without prior notice or liability, for any reason, including if you breach the terms of this Agreement. Upon termination, your right to use the App will immediately cease.</p>
+
+<h2>12. Governing Law</h2>
+<p>This Agreement shall be governed by and construed in accordance with the laws of the State of Texas, United States, without regard to its conflict of law provisions.</p>
+
+<h2>13. Changes to This Agreement</h2>
+<p>We reserve the right to modify this Agreement at any time. Changes will be reflected by updating the date at the top of this page. Your continued use of the App after changes are posted constitutes your acceptance of the revised Agreement.</p>
+
+<h2>14. Contact</h2>
+<p>If you have questions about this Agreement, contact us at: <a href="mailto:support@terrorllc.com">support@terrorllc.com</a></p>
+</body>
+</html>

--- a/trumpaccount/privacy-policy/index.html
+++ b/trumpaccount/privacy-policy/index.html
@@ -1,0 +1,75 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<title>TrumpAccount - Privacy Policy</title>
+<style>
+  body { font-family: -apple-system, BlinkMacSystemFont, sans-serif; max-width: 700px; margin: 0 auto; padding: 24px; color: #222; line-height: 1.6; }
+  h1 { font-size: 24px; }
+  h2 { font-size: 18px; margin-top: 32px; }
+  p, li { font-size: 15px; }
+  .date { color: #666; font-size: 14px; }
+</style>
+</head>
+<body>
+<h1>Privacy Policy</h1>
+<p class="date">Last updated: February 6, 2026</p>
+
+<p>TrumpAccount ("we", "our", or "the app") is a mobile application developed by Terror LLC that helps you track and manage 530A children's savings account contributions. Your financial and personal data is sensitive, and we take its privacy and security very seriously. This policy describes how we collect, use, and protect your information.</p>
+
+<p><strong>Disclaimer:</strong> TrumpAccount is an independent third-party tracking tool and is NOT affiliated with, endorsed by, or sponsored by the United States government, the Internal Revenue Service (IRS), the Department of the Treasury, or any government agency. The app does not provide financial, tax, or investment advice.</p>
+
+<h2>Information We Collect</h2>
+<ul>
+  <li><strong>Account Information:</strong> When you sign in with Apple, we receive your Apple ID email address (or a private relay address) and a unique user identifier. We use this solely to create and manage your account.</li>
+  <li><strong>Children's Information:</strong> Names and dates of birth of children you add to the app for the purpose of tracking their 530A savings accounts. This information is provided voluntarily by you and is used only for account tracking within the app.</li>
+  <li><strong>Financial Contribution Data:</strong> Contribution amounts, dates, and related details you record in the app to track savings activity.</li>
+  <li><strong>Partial SSN (Optional):</strong> If you choose to store the last 4 digits of a child's Social Security Number for your own reference, this data is stored securely. This field is entirely optional and is never required.</li>
+  <li><strong>Subscription Information:</strong> If you subscribe to TrumpAccount Premium, purchase and subscription status is managed through Apple's StoreKit in-app purchase system.</li>
+</ul>
+
+<h2>How We Use Your Information</h2>
+<ul>
+  <li>To authenticate your account and provide app functionality</li>
+  <li>To store and display your children's savings account information</li>
+  <li>To track contributions and calculate account balances</li>
+  <li>To generate summaries and insights about your savings activity</li>
+  <li>To manage your subscription status</li>
+</ul>
+
+<h2>Third-Party Services</h2>
+<p>We use the following third-party services:</p>
+<ul>
+  <li><strong>Supabase:</strong> Authentication and database storage for your account and savings records</li>
+  <li><strong>Apple StoreKit:</strong> Subscription and in-app purchase management</li>
+  <li><strong>Apple Sign In:</strong> Authentication</li>
+</ul>
+
+<h2>Data Retention</h2>
+<p>Your account data, children's information, and financial records are retained as long as your account is active. You may delete your account and all associated data at any time from within the app's settings, or by contacting us directly.</p>
+
+<h2>Data Sharing</h2>
+<p>We do not sell, trade, or share your personal information, financial data, or children's information with third parties for advertising or marketing purposes. Data is only shared with the third-party services listed above as necessary to provide app functionality. Your financial data and children's personal information are never shared with advertisers, data brokers, or any parties beyond what is required to operate the app.</p>
+
+<h2>Data Security</h2>
+<p>We use industry-standard security measures to protect your sensitive financial and personal data, including encrypted connections (HTTPS/TLS), secure authentication, encrypted database storage, and strict access controls. Partial SSN data, if provided, is stored with additional encryption protections. Children's personal information is treated with the highest level of care and security.</p>
+
+<h2>Children's Privacy</h2>
+<p>TrumpAccount is designed for parents and guardians to track their children's savings accounts. The app is intended for use by adults (parents or guardians) and is not directed at children. We do not knowingly allow children under 13 to create accounts or use the app directly. The children's information stored in the app (names, dates of birth) is provided by the parent or guardian and is used solely for savings account tracking purposes.</p>
+
+<h2>Your Rights</h2>
+<ul>
+  <li>You can view all data stored in your account at any time within the app</li>
+  <li>You can delete your account and all associated data from the app's settings</li>
+  <li>You can remove individual children's profiles and their associated data at any time</li>
+  <li>You can request a copy of your data by contacting us</li>
+</ul>
+
+<h2>Changes to This Policy</h2>
+<p>We may update this policy from time to time. Changes will be reflected by updating the date at the top of this page.</p>
+
+<h2>Contact</h2>
+<p>If you have questions about this privacy policy or want to request data deletion, contact us at: <a href="mailto:support@terrorllc.com">support@terrorllc.com</a></p>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- Add privacy policy and EULA pages for **BP Companion** (blood pressure tracking app with HealthKit integration)
- Add privacy policy and EULA pages for **TrumpAccount** (530A children's savings account tracker)
- All pages use clean URL directory structure for GitHub Pages (e.g., `/bpcompanion/privacy-policy/`)
- Styling matches the existing Ace privacy policy HTML template

## Files Added
| File | URL |
|------|-----|
| `bpcompanion/privacy-policy/index.html` | https://terrorapps.github.io/bpcompanion/privacy-policy |
| `bpcompanion/eula/index.html` | https://terrorapps.github.io/bpcompanion/eula |
| `trumpaccount/privacy-policy/index.html` | https://terrorapps.github.io/trumpaccount/privacy-policy |
| `trumpaccount/eula/index.html` | https://terrorapps.github.io/trumpaccount/eula |

## Key Legal Provisions
### BP Companion
- **Privacy Policy**: Covers HealthKit data handling, blood pressure/heart rate data, medication info, Apple Sign In, Supabase, StoreKit subscriptions, account deletion rights
- **EULA**: Medical disclaimer (not medical advice), subscription auto-renewal terms, limitation of liability, governing law (Texas)

### TrumpAccount
- **Privacy Policy**: Covers children's names/DOBs, financial contribution data, optional partial SSN, Apple Sign In, Supabase, StoreKit subscriptions, account deletion rights
- **EULA**: Financial disclaimer (not financial advice), government non-affiliation disclaimer, children's data responsibilities, subscription auto-renewal terms, limitation of liability, governing law (Texas)

## Token Usage
- Feature Dev Agent: ~8,000 tokens
- Test Dev Agent: N/A (static HTML, no tests needed)
- Code Review Agent: ~2,000 tokens
- Security Audit Agent: ~2,000 tokens
- Orchestration: ~3,000 tokens
- **Total: ~15,000 tokens**

🤖 Generated with [Claude Code](https://claude.com/claude-code)